### PR TITLE
feat: 이슈 생성을 제외한 이슈 관련 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-
-src/main/resources/data.sql

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 
-data.sql
+src/main/resources/data.sql

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+data.sql

--- a/build.gradle
+++ b/build.gradle
@@ -23,16 +23,28 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2024.0.1")
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/trendist/issue_service/IssueServiceApplication.java
+++ b/src/main/java/com/trendist/issue_service/IssueServiceApplication.java
@@ -2,8 +2,12 @@ package com.trendist.issue_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableJpaAuditing
 public class IssueServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
@@ -1,5 +1,7 @@
 package com.trendist.issue_service.domain.issue.controller;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllResponse;
+import com.trendist.issue_service.domain.issue.dto.response.IssueGetResponse;
 import com.trendist.issue_service.domain.issue.service.IssueService;
 import com.trendist.issue_service.global.response.ApiResponse;
 
@@ -24,10 +27,15 @@ public class IssueController {
 		return ApiResponse.onSuccess(issueService.getAllIssues(page));
 	}
 
-	@GetMapping("/{keyword}")
+	@GetMapping("/keyword/{keyword}")
 	public ApiResponse<Page<IssueGetAllResponse>> getAllIssuesByKeyword(
 		@RequestParam(defaultValue = "0") int page,
 		@PathVariable(name = "keyword") String keyword) {
 		return ApiResponse.onSuccess(issueService.getAllIssuesByKeyword(page, keyword));
+	}
+
+	@GetMapping("/{id}")
+	public ApiResponse<IssueGetResponse> getIssue(@PathVariable(name = "id") UUID id) {
+		return ApiResponse.onSuccess(issueService.getIssue(id));
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.trendist.issue_service.domain.issue.dto.response.BookmarkResponse;
+import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllBookmarkedResponse;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllResponse;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetResponse;
 import com.trendist.issue_service.domain.issue.service.IssueService;
@@ -44,5 +45,11 @@ public class IssueController {
 	@PostMapping("{id}/bookmark")
 	public ApiResponse<BookmarkResponse> toggleBookmark(@PathVariable(name = "id") UUID id) {
 		return ApiResponse.onSuccess(issueService.toggleBookmark(id));
+	}
+
+	@GetMapping("/bookmark")
+	public ApiResponse<Page<IssueGetAllBookmarkedResponse>> getAllIssuesBookmarked(
+		@RequestParam(defaultValue = "0") int page) {
+		return ApiResponse.onSuccess(issueService.getAllIssuesBookmarked(page));
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
@@ -2,6 +2,7 @@ package com.trendist.issue_service.domain.issue.controller;
 
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,5 +22,12 @@ public class IssueController {
 	@GetMapping
 	public ApiResponse<Page<IssueGetAllResponse>> getAllIssues(@RequestParam(defaultValue = "0") int page) {
 		return ApiResponse.onSuccess(issueService.getAllIssues(page));
+	}
+
+	@GetMapping("/{keyword}")
+	public ApiResponse<Page<IssueGetAllResponse>> getAllIssuesByKeyword(
+		@RequestParam(defaultValue = "0") int page,
+		@PathVariable(name = "keyword") String keyword) {
+		return ApiResponse.onSuccess(issueService.getAllIssuesByKeyword(page, keyword));
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
@@ -5,10 +5,12 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.trendist.issue_service.domain.issue.dto.response.BookmarkResponse;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllResponse;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetResponse;
 import com.trendist.issue_service.domain.issue.service.IssueService;
@@ -37,5 +39,10 @@ public class IssueController {
 	@GetMapping("/{id}")
 	public ApiResponse<IssueGetResponse> getIssue(@PathVariable(name = "id") UUID id) {
 		return ApiResponse.onSuccess(issueService.getIssue(id));
+	}
+
+	@PostMapping("{id}/bookmark")
+	public ApiResponse<BookmarkResponse> toggleBookmark(@PathVariable(name = "id") UUID id) {
+		return ApiResponse.onSuccess(issueService.toggleBookmark(id));
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
@@ -1,0 +1,25 @@
+package com.trendist.issue_service.domain.issue.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllResponse;
+import com.trendist.issue_service.domain.issue.service.IssueService;
+import com.trendist.issue_service.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/issues")
+public class IssueController {
+	private final IssueService issueService;
+
+	@GetMapping
+	public ApiResponse<Page<IssueGetAllResponse>> getAllIssues(@RequestParam(defaultValue = "0") int page) {
+		return ApiResponse.onSuccess(issueService.getAllIssues(page));
+	}
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/controller/IssueController.java
@@ -17,6 +17,7 @@ import com.trendist.issue_service.domain.issue.dto.response.IssueGetResponse;
 import com.trendist.issue_service.domain.issue.service.IssueService;
 import com.trendist.issue_service.global.response.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -25,11 +26,19 @@ import lombok.RequiredArgsConstructor;
 public class IssueController {
 	private final IssueService issueService;
 
+	@Operation(
+		summary = "이슈 전체 조회",
+		description = "사용자가 전체 이슈를 조회합니다."
+	)
 	@GetMapping
 	public ApiResponse<Page<IssueGetAllResponse>> getAllIssues(@RequestParam(defaultValue = "0") int page) {
 		return ApiResponse.onSuccess(issueService.getAllIssues(page));
 	}
 
+	@Operation(
+		summary = "키워드 별 이슈 전체 조회",
+		description = "사용자가 특정 키워드에 해당하는 이슈 전체를 조회합니다."
+	)
 	@GetMapping("/keyword/{keyword}")
 	public ApiResponse<Page<IssueGetAllResponse>> getAllIssuesByKeyword(
 		@RequestParam(defaultValue = "0") int page,
@@ -37,16 +46,28 @@ public class IssueController {
 		return ApiResponse.onSuccess(issueService.getAllIssuesByKeyword(page, keyword));
 	}
 
+	@Operation(
+		summary = "특정 이슈 상세 조회",
+		description = "사용자가 특정 이슈를 상세 조회합니다."
+	)
 	@GetMapping("/{id}")
 	public ApiResponse<IssueGetResponse> getIssue(@PathVariable(name = "id") UUID id) {
 		return ApiResponse.onSuccess(issueService.getIssue(id));
 	}
 
+	@Operation(
+		summary = "이슈 북마크 등록/해제",
+		description = "사용자가 특정 이슈를 북마크 등록하거나 해제합니다."
+	)
 	@PostMapping("{id}/bookmark")
 	public ApiResponse<BookmarkResponse> toggleBookmark(@PathVariable(name = "id") UUID id) {
 		return ApiResponse.onSuccess(issueService.toggleBookmark(id));
 	}
 
+	@Operation(
+		summary = "마이페이지 북마크한 이슈 조회",
+		description = "사용자가 북마크한 이슈들을 조회합니다."
+	)
 	@GetMapping("/bookmark")
 	public ApiResponse<Page<IssueGetAllBookmarkedResponse>> getAllIssuesBookmarked(
 		@RequestParam(defaultValue = "0") int page) {

--- a/src/main/java/com/trendist/issue_service/domain/issue/domain/Issue.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/domain/Issue.java
@@ -1,0 +1,48 @@
+package com.trendist.issue_service.domain.issue.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.issue_service.global.common.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "issues")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Issue extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "issue_id")
+	private UUID id;
+
+	@Column(name = "title")
+	private String title;
+
+	@Column(name = "content")
+	private String content;
+
+	@Column(name = "issue_date")
+	private LocalDateTime issueDate;
+
+	@Column(name = "site_url")
+	private String siteUrl;
+
+	@Column(name = "image_url")
+	private String imageUrl;
+
+	@Column(name = "keyword")
+	private String keyword;
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/domain/IssueBookmark.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/domain/IssueBookmark.java
@@ -1,0 +1,45 @@
+package com.trendist.issue_service.domain.issue.domain;
+
+import java.util.UUID;
+
+import com.trendist.issue_service.global.common.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+	name = "issue_bookmarks",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "issue_id"})
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IssueBookmark extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "bookmark_id")
+	private UUID id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "issue_id", nullable = false)
+	private Issue issue;
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/dto/response/BookmarkResponse.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/dto/response/BookmarkResponse.java
@@ -1,0 +1,24 @@
+package com.trendist.issue_service.domain.issue.dto.response;
+
+import java.util.UUID;
+
+import com.trendist.issue_service.domain.issue.domain.IssueBookmark;
+
+import lombok.Builder;
+
+@Builder
+public record BookmarkResponse(
+	UUID bookmarkId,
+	UUID userId,
+	UUID issueId,
+	Boolean bookmarked
+) {
+	public static BookmarkResponse of(IssueBookmark issueBookmark, boolean bookmarked) {
+		return BookmarkResponse.builder()
+			.bookmarkId(issueBookmark.getId())
+			.userId(issueBookmark.getUserId())
+			.issueId(issueBookmark.getIssue().getId())
+			.bookmarked(bookmarked)
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetAllBookmarkedResponse.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetAllBookmarkedResponse.java
@@ -1,0 +1,27 @@
+package com.trendist.issue_service.domain.issue.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.issue_service.domain.issue.domain.IssueBookmark;
+
+import lombok.Builder;
+
+@Builder
+public record IssueGetAllBookmarkedResponse(
+	UUID bookmarkId,
+	UUID issueId,
+	String title,
+	String keyword,
+	LocalDateTime issueDate
+) {
+	public static IssueGetAllBookmarkedResponse from(IssueBookmark bookmark) {
+		return IssueGetAllBookmarkedResponse.builder()
+			.bookmarkId(bookmark.getId())
+			.issueId(bookmark.getIssue().getId())
+			.title(bookmark.getIssue().getTitle())
+			.keyword(bookmark.getIssue().getKeyword())
+			.issueDate(bookmark.getIssue().getIssueDate())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetAllResponse.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetAllResponse.java
@@ -1,0 +1,31 @@
+package com.trendist.issue_service.domain.issue.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.issue_service.domain.issue.domain.Issue;
+
+import lombok.Builder;
+
+@Builder
+public record IssueGetAllResponse(
+	UUID id,
+	String title,
+	String content,
+	LocalDateTime issueDate,
+	String siteUrl,
+	String imageUrl,
+	String keyword
+) {
+	public static IssueGetAllResponse from(Issue issue) {
+		return IssueGetAllResponse.builder()
+			.id(issue.getId())
+			.title(issue.getTitle())
+			.content(issue.getContent())
+			.issueDate(issue.getIssueDate())
+			.siteUrl(issue.getSiteUrl())
+			.imageUrl(issue.getImageUrl())
+			.keyword(issue.getKeyword())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetAllResponse.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetAllResponse.java
@@ -1,6 +1,5 @@
 package com.trendist.issue_service.domain.issue.dto.response;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.trendist.issue_service.domain.issue.domain.Issue;
@@ -12,14 +11,16 @@ public record IssueGetAllResponse(
 	UUID id,
 	String title,
 	String imageUrl,
-	String keyword
+	String keyword,
+	Boolean bookmarked
 ) {
-	public static IssueGetAllResponse from(Issue issue) {
+	public static IssueGetAllResponse of(Issue issue, Boolean bookmarked) {
 		return IssueGetAllResponse.builder()
 			.id(issue.getId())
 			.title(issue.getTitle())
 			.imageUrl(issue.getImageUrl())
 			.keyword(issue.getKeyword())
+			.bookmarked(bookmarked)
 			.build();
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetAllResponse.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetAllResponse.java
@@ -11,9 +11,6 @@ import lombok.Builder;
 public record IssueGetAllResponse(
 	UUID id,
 	String title,
-	String content,
-	LocalDateTime issueDate,
-	String siteUrl,
 	String imageUrl,
 	String keyword
 ) {
@@ -21,9 +18,6 @@ public record IssueGetAllResponse(
 		return IssueGetAllResponse.builder()
 			.id(issue.getId())
 			.title(issue.getTitle())
-			.content(issue.getContent())
-			.issueDate(issue.getIssueDate())
-			.siteUrl(issue.getSiteUrl())
 			.imageUrl(issue.getImageUrl())
 			.keyword(issue.getKeyword())
 			.build();

--- a/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetResponse.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetResponse.java
@@ -1,0 +1,31 @@
+package com.trendist.issue_service.domain.issue.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.issue_service.domain.issue.domain.Issue;
+
+import lombok.Builder;
+
+@Builder
+public record IssueGetResponse(
+	UUID id,
+	String title,
+	String content,
+	LocalDateTime issueDate,
+	String siteUrl,
+	String imageUrl,
+	String keyword
+) {
+	public static IssueGetResponse from(Issue issue) {
+		return IssueGetResponse.builder()
+			.id(issue.getId())
+			.title(issue.getTitle())
+			.content(issue.getContent())
+			.issueDate(issue.getIssueDate())
+			.siteUrl(issue.getSiteUrl())
+			.imageUrl(issue.getImageUrl())
+			.keyword(issue.getKeyword())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetResponse.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/dto/response/IssueGetResponse.java
@@ -15,9 +15,10 @@ public record IssueGetResponse(
 	LocalDateTime issueDate,
 	String siteUrl,
 	String imageUrl,
-	String keyword
+	String keyword,
+	Boolean bookmarked
 ) {
-	public static IssueGetResponse from(Issue issue) {
+	public static IssueGetResponse of(Issue issue, Boolean bookmarked) {
 		return IssueGetResponse.builder()
 			.id(issue.getId())
 			.title(issue.getTitle())
@@ -26,6 +27,7 @@ public record IssueGetResponse(
 			.siteUrl(issue.getSiteUrl())
 			.imageUrl(issue.getImageUrl())
 			.keyword(issue.getKeyword())
+			.bookmarked(bookmarked)
 			.build();
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueBookmarkRepository.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueBookmarkRepository.java
@@ -1,5 +1,6 @@
 package com.trendist.issue_service.domain.issue.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,4 +18,6 @@ public interface IssueBookmarkRepository extends JpaRepository<IssueBookmark, UU
 	void deleteByUserIdAndIssue_Id(UUID userId, UUID issueId);
 
 	Page<IssueBookmark> findAllByUserId(UUID userId, Pageable pageable);
+
+	List<IssueBookmark> findAllByUserIdAndIssue_IdIn(UUID userId, List<UUID> issueIds);
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueBookmarkRepository.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueBookmarkRepository.java
@@ -1,0 +1,16 @@
+package com.trendist.issue_service.domain.issue.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trendist.issue_service.domain.issue.domain.IssueBookmark;
+
+public interface IssueBookmarkRepository extends JpaRepository<IssueBookmark, UUID> {
+	Optional<IssueBookmark> findByUserIdAndIssue_Id(UUID userId, UUID issueId);
+
+	Boolean existsByUserIdAndIssue_Id(UUID userId, UUID issueId);
+
+	void deleteByUserIdAndIssue_Id(UUID userId, UUID issueId);
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueBookmarkRepository.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueBookmarkRepository.java
@@ -3,6 +3,8 @@ package com.trendist.issue_service.domain.issue.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.trendist.issue_service.domain.issue.domain.IssueBookmark;
@@ -13,4 +15,6 @@ public interface IssueBookmarkRepository extends JpaRepository<IssueBookmark, UU
 	Boolean existsByUserIdAndIssue_Id(UUID userId, UUID issueId);
 
 	void deleteByUserIdAndIssue_Id(UUID userId, UUID issueId);
+
+	Page<IssueBookmark> findAllByUserId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueRepository.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueRepository.java
@@ -2,9 +2,12 @@ package com.trendist.issue_service.domain.issue.repository;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.trendist.issue_service.domain.issue.domain.Issue;
 
 public interface IssueRepository extends JpaRepository<Issue, UUID> {
+	Page<Issue> findAllByKeyword(Pageable pageable, String keyword);
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueRepository.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/repository/IssueRepository.java
@@ -1,0 +1,10 @@
+package com.trendist.issue_service.domain.issue.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trendist.issue_service.domain.issue.domain.Issue;
+
+public interface IssueRepository extends JpaRepository<Issue, UUID> {
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
@@ -1,0 +1,24 @@
+package com.trendist.issue_service.domain.issue.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllResponse;
+import com.trendist.issue_service.domain.issue.repository.IssueRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class IssueService {
+	private final IssueRepository issueRepository;
+
+	public Page<IssueGetAllResponse> getAllIssues(int page) {
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("issueDate").descending());
+		return issueRepository.findAll(pageable)
+			.map(IssueGetAllResponse::from);
+	}
+}

--- a/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
@@ -7,12 +7,17 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.trendist.issue_service.domain.issue.domain.Issue;
+import com.trendist.issue_service.domain.issue.domain.IssueBookmark;
+import com.trendist.issue_service.domain.issue.dto.response.BookmarkResponse;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllResponse;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetResponse;
+import com.trendist.issue_service.domain.issue.repository.IssueBookmarkRepository;
 import com.trendist.issue_service.domain.issue.repository.IssueRepository;
 import com.trendist.issue_service.global.exception.ApiException;
+import com.trendist.issue_service.global.feign.user.client.UserServiceClient;
 import com.trendist.issue_service.global.response.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class IssueService {
 	private final IssueRepository issueRepository;
+	private final IssueBookmarkRepository issueBookmarkRepository;
+	private final UserServiceClient userServiceClient;
 
 	public Page<IssueGetAllResponse> getAllIssues(int page) {
 		Pageable pageable = PageRequest.of(page, 12, Sort.by("issueDate").descending());
@@ -39,5 +46,34 @@ public class IssueService {
 			.orElseThrow(() -> new ApiException(ErrorStatus._ISSUE_NOT_FOUND));
 
 		return IssueGetResponse.from(issue);
+	}
+
+	@Transactional
+	public BookmarkResponse toggleBookmark(UUID issueId) {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+
+		Issue issue = issueRepository.findById(issueId)
+			.orElseThrow(() -> new ApiException(ErrorStatus._ISSUE_NOT_FOUND));
+
+		IssueBookmark bookmark;
+		boolean bookmarked;
+
+		if (!issueBookmarkRepository.existsByUserIdAndIssue_Id(userId, issueId)) {
+			bookmark = IssueBookmark.builder()
+				.userId(userId)
+				.issue(issue)
+				.build();
+
+			issueBookmarkRepository.save(bookmark);
+			bookmarked = true;
+		} else {
+			bookmark = issueBookmarkRepository.findByUserIdAndIssue_Id(userId, issueId)
+				.orElseThrow(() -> new ApiException(ErrorStatus._BOOKMARK_NOT_FOUND));
+
+			issueBookmarkRepository.deleteByUserIdAndIssue_Id(userId, issueId);
+			bookmarked = false;
+		}
+
+		return BookmarkResponse.of(bookmark, bookmarked);
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.trendist.issue_service.domain.issue.domain.Issue;
 import com.trendist.issue_service.domain.issue.domain.IssueBookmark;
 import com.trendist.issue_service.domain.issue.dto.response.BookmarkResponse;
+import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllBookmarkedResponse;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllResponse;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetResponse;
 import com.trendist.issue_service.domain.issue.repository.IssueBookmarkRepository;
@@ -75,5 +76,14 @@ public class IssueService {
 		}
 
 		return BookmarkResponse.of(bookmark, bookmarked);
+	}
+
+	public Page<IssueGetAllBookmarkedResponse> getAllIssuesBookmarked(int page) {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("issue.issueDate").descending());
+
+		return issueBookmarkRepository.findAllByUserId(userId, pageable)
+			.map(IssueGetAllBookmarkedResponse::from);
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
@@ -1,13 +1,19 @@
 package com.trendist.issue_service.domain.issue.service;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import com.trendist.issue_service.domain.issue.domain.Issue;
 import com.trendist.issue_service.domain.issue.dto.response.IssueGetAllResponse;
+import com.trendist.issue_service.domain.issue.dto.response.IssueGetResponse;
 import com.trendist.issue_service.domain.issue.repository.IssueRepository;
+import com.trendist.issue_service.global.exception.ApiException;
+import com.trendist.issue_service.global.response.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,5 +32,12 @@ public class IssueService {
 		Pageable pageable = PageRequest.of(page, 12, Sort.by("issueDate").descending());
 		return issueRepository.findAllByKeyword(pageable, keyword)
 			.map(IssueGetAllResponse::from);
+	}
+
+	public IssueGetResponse getIssue(UUID id) {
+		Issue issue = issueRepository.findById(id)
+			.orElseThrow(() -> new ApiException(ErrorStatus._ISSUE_NOT_FOUND));
+
+		return IssueGetResponse.from(issue);
 	}
 }

--- a/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
+++ b/src/main/java/com/trendist/issue_service/domain/issue/service/IssueService.java
@@ -17,8 +17,14 @@ public class IssueService {
 	private final IssueRepository issueRepository;
 
 	public Page<IssueGetAllResponse> getAllIssues(int page) {
-		Pageable pageable = PageRequest.of(page, 10, Sort.by("issueDate").descending());
+		Pageable pageable = PageRequest.of(page, 12, Sort.by("issueDate").descending());
 		return issueRepository.findAll(pageable)
+			.map(IssueGetAllResponse::from);
+	}
+
+	public Page<IssueGetAllResponse> getAllIssuesByKeyword(int page, String keyword) {
+		Pageable pageable = PageRequest.of(page, 12, Sort.by("issueDate").descending());
+		return issueRepository.findAllByKeyword(pageable, keyword)
 			.map(IssueGetAllResponse::from);
 	}
 }

--- a/src/main/java/com/trendist/issue_service/global/config/feign/FeignAuthConfig.java
+++ b/src/main/java/com/trendist/issue_service/global/config/feign/FeignAuthConfig.java
@@ -1,0 +1,26 @@
+package com.trendist.issue_service.global.config.feign;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import feign.RequestInterceptor;
+
+@Configuration
+public class FeignAuthConfig {
+	@Bean
+	public RequestInterceptor authInterceptor() {
+		return requestTemplate -> {
+			ServletRequestAttributes attrs =
+				(ServletRequestAttributes)RequestContextHolder.getRequestAttributes();
+			if (attrs != null) {
+				String auth = attrs.getRequest().getHeader(HttpHeaders.AUTHORIZATION);
+				if (auth != null) {
+					requestTemplate.header(HttpHeaders.AUTHORIZATION, auth);
+				}
+			}
+		};
+	}
+}

--- a/src/main/java/com/trendist/issue_service/global/feign/user/client/UserServiceClient.java
+++ b/src/main/java/com/trendist/issue_service/global/feign/user/client/UserServiceClient.java
@@ -1,0 +1,26 @@
+package com.trendist.issue_service.global.feign.user.client;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.trendist.issue_service.global.feign.user.dto.UserProfileResponse;
+import com.trendist.issue_service.global.response.ApiResponse;
+
+@FeignClient(name = "user-service")
+public interface UserServiceClient {
+
+	@GetMapping("/users/profile")
+	ApiResponse<UserProfileResponse> getMyProfile(
+		@RequestHeader(HttpHeaders.AUTHORIZATION) String authorization
+	);
+
+	@GetMapping("/users/profile/{userId}")
+	ApiResponse<UserProfileResponse> getUserProfile(
+		@PathVariable(name = "userId") UUID userId
+	);
+}

--- a/src/main/java/com/trendist/issue_service/global/feign/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/trendist/issue_service/global/feign/user/dto/UserProfileResponse.java
@@ -1,0 +1,19 @@
+package com.trendist.issue_service.global.feign.user.dto;
+
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record UserProfileResponse(
+	UUID id,
+	String username,
+	String email,
+	String nickname,
+	String keyword,
+	String profileUrl,
+	int exp,
+	String tierName,
+	String tierImageUrl
+) {
+}

--- a/src/main/java/com/trendist/issue_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/issue_service/global/response/status/ErrorStatus.java
@@ -24,7 +24,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 존재하지 않습니다"),
 	_USER_NOT_FIRST_LOGIN(HttpStatus.BAD_REQUEST, "USER_002", "최초 로그인한 유저가 아닙니다."),
 
-	_TIER_NOT_FOUND(HttpStatus.NOT_FOUND, "TIER_001", "해당 티어를 찾을 수 없습니다.");
+	_TIER_NOT_FOUND(HttpStatus.NOT_FOUND, "TIER_001", "해당 티어를 찾을 수 없습니다."),
+
+	_ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "ISSUE_001", "해당 이슈를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/trendist/issue_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/issue_service/global/response/status/ErrorStatus.java
@@ -26,7 +26,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	_TIER_NOT_FOUND(HttpStatus.NOT_FOUND, "TIER_001", "해당 티어를 찾을 수 없습니다."),
 
-	_ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "ISSUE_001", "해당 이슈를 찾을 수 없습니다.");
+	_ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "ISSUE_001", "해당 이슈를 찾을 수 없습니다."),
+
+	_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK_001", "해당 북마크를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,17 @@
+server:
+  port: 8083
+
 spring:
   application:
     name: user-service
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connect-timeout: 5000
+            read-timeout: 5000
+
   datasource:
     url: ${DB_URL}
     username: root
@@ -18,3 +29,12 @@ spring:
     defer-datasource-initialization: true
 
 server-uri: http://localhost:8080
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   application:
-    name: user-service
+    name: issue-service
   cloud:
     openfeign:
       client:
@@ -28,7 +28,7 @@ spring:
         use_sql_comments: true
     defer-datasource-initialization: true
 
-server-uri: http://localhost:8080
+server-uri: http://localhost:8083
 
 eureka:
   client:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,54 @@
+INSERT INTO issues (
+    issue_id,
+    title,
+    content,
+    issue_date,
+    site_url,
+    image_url,
+    keyword
+) VALUES
+      (
+          UUID(),
+          '첫 번째 이슈 제목',
+          '이것은 더미 콘텐츠입니다 – 첫 번째 이슈 예시입니다.',
+          '2025-05-01 09:00:00',
+          'https://example.com/issue/1',
+          'https://example.com/images/issue1.png',
+          'Environment'
+      ),
+      (
+          UUID(),
+          '두 번째 이슈 제목',
+          '이것은 더미 콘텐츠입니다 – 두 번째 이슈 예시입니다.',
+          '2025-05-02 10:30:00',
+          'https://example.com/issue/2',
+          'https://example.com/images/issue2.png',
+          'Environment'
+      ),
+      (
+          UUID(),
+          '세 번째 이슈 제목',
+          '이것은 더미 콘텐츠입니다 – 세 번째 이슈 예시입니다.',
+          '2025-05-03 11:45:00',
+          'https://example.com/issue/3',
+          'https://example.com/images/issue3.png',
+          'Society'
+      ),
+      (
+          UUID(),
+          '네 번째 이슈 제목',
+          '이것은 더미 콘텐츠입니다 – 네 번째 이슈 예시입니다.',
+          '2025-05-04 14:15:00',
+          'https://example.com/issue/4',
+          'https://example.com/images/issue4.png',
+          'Society'
+      ),
+      (
+          UUID(),
+          '다섯 번째 이슈 제목',
+          '이것은 더미 콘텐츠입니다 – 다섯 번째 이슈 예시입니다.',
+          '2025-05-05 16:20:00',
+          'https://example.com/issue/5',
+          'https://example.com/images/issue5.png',
+          'Environment'
+      );

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -8,7 +8,7 @@ INSERT INTO issues (
     keyword
 ) VALUES
       (
-          UUID(),
+          UNHEX(REPLACE(UUID(), '-', '')),
           '첫 번째 이슈 제목',
           '이것은 더미 콘텐츠입니다 – 첫 번째 이슈 예시입니다.',
           '2025-05-01 09:00:00',
@@ -17,7 +17,7 @@ INSERT INTO issues (
           'Environment'
       ),
       (
-          UUID(),
+          UNHEX(REPLACE(UUID(), '-', '')),
           '두 번째 이슈 제목',
           '이것은 더미 콘텐츠입니다 – 두 번째 이슈 예시입니다.',
           '2025-05-02 10:30:00',
@@ -26,7 +26,7 @@ INSERT INTO issues (
           'Environment'
       ),
       (
-          UUID(),
+          UNHEX(REPLACE(UUID(), '-', '')),
           '세 번째 이슈 제목',
           '이것은 더미 콘텐츠입니다 – 세 번째 이슈 예시입니다.',
           '2025-05-03 11:45:00',
@@ -35,7 +35,7 @@ INSERT INTO issues (
           'Society'
       ),
       (
-          UUID(),
+          UNHEX(REPLACE(UUID(), '-', '')),
           '네 번째 이슈 제목',
           '이것은 더미 콘텐츠입니다 – 네 번째 이슈 예시입니다.',
           '2025-05-04 14:15:00',
@@ -44,7 +44,7 @@ INSERT INTO issues (
           'Society'
       ),
       (
-          UUID(),
+          UNHEX(REPLACE(UUID(), '-', '')),
           '다섯 번째 이슈 제목',
           '이것은 더미 콘텐츠입니다 – 다섯 번째 이슈 예시입니다.',
           '2025-05-05 16:20:00',


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**우선 구현 기능 확인 전 모든 조회 기능의 경우 현재 로그인한 사용자가 북마크를 했는지 안했는지 여부를 확인할 수 있도록 응답값에 반환하도록 하였습니다.**
**참고로 presigned url을 사용하지 않았고 필요하지 않다고 판단하였습니다. 왜냐하면 크롤링해서 가져오는 이슈의 이미지의 경우 이미지 경로를 받아오는 것이기 때문에 s3 버킷에 올릴 필요가 없기 때문입니다.**

**1. 이슈 전체 조회를 구현하였습니다.**
<img width="755" alt="image" src="https://github.com/user-attachments/assets/f7768c41-3304-4838-9cb6-867de6d8beab" />

**2. 키워드 별 이슈 조회를 구현하였습니다.**
<img width="749" alt="image" src="https://github.com/user-attachments/assets/1e198e0f-c596-4069-89ae-29dc7fc001fe" />

**3. 특정 이슈 상세 조회를 구현하였습니다.**
<img width="751" alt="image" src="https://github.com/user-attachments/assets/5e0b8978-b57c-4479-bb28-7a6827c131a7" />

**4. 특정 이슈 북마크 등록하는 기능을 구현하였습니다.**
- 북마크 등록 및 해제를 하나의 기능으로 구현하였습니다.
<img width="756" alt="image" src="https://github.com/user-attachments/assets/5b520c5f-6aee-4ace-8977-e6dd9441603b" />

**5. 현재 로그인한 본인이 북마크를 등록한 이슈들을 조회하는 기능을 구현하였습니다.**
<img width="752" alt="image" src="https://github.com/user-attachments/assets/d4339c84-248d-430b-8261-38f1194009b4" />

---

## 🔗 관련 이슈
- close #1 

---

## 💡 추가 사항
**활동 기능 구현이 완료되면 서비스 간 통신을 통해 이슈와 동일한 키워드에 해당하는 활동들을 이슈 상세 조회 시 보여주는, 활동추천 기능을 구현해야합니다.**
**이슈 생성의 경우 스프링 부트는 관여하지 않으며 전적으로 플라스크 api와 프론트엔드의 통신을 통해 이루어질 예정입니다. 스프링부트는 플라스크 api가 저장한 정보를 가지고 옵니다.**